### PR TITLE
ENT-2774: Extended quote verification

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'com.github.johnrengelman.shadow'
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation "info.picocli:picocli:$picocli_version"
+    implementation "com.r3.sgx:enclavelet-host-client:$oblivium_version"
+    implementation "com.r3.sgx:api-core-common:$oblivium_version"
+}
+
+shadowJar {
+    baseName = 'rng-client'
+    manifest {
+        attributes("Main-Class": "com.r3.sgx.rng.client.RngClientCli")
+    }
+    zip64 true
+}

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/GetAttestationCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/GetAttestationCommand.kt
@@ -20,7 +20,7 @@ class GetAttestationCommand : Callable<Unit> {
         RngEnclaveletHostClient.withClient(hostAddress) { client ->
             val quote = client.getAttestation()
             val base64Quote = Base64.getEncoder().encode(quote.toByteArray())
-            System.out.print(String(base64Quote))
+            print(String(base64Quote))
         }
     }
 }

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/GetAttestationCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/GetAttestationCommand.kt
@@ -1,0 +1,26 @@
+package com.r3.sgx.rng.client
+
+import picocli.CommandLine
+import java.util.*
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+        name = "get-attestation",
+        description = ["Retrieves attestation data from a running enclavelet host"],
+        mixinStandardHelpOptions = true
+)
+class GetAttestationCommand : Callable<Unit> {
+    @CommandLine.Parameters(
+            index = "0",
+            description = ["The address of the RNG enclavelet host"]
+    )
+    var hostAddress: String = "localhost:8080"
+
+    override fun call() {
+        RngEnclaveletHostClient.withClient(hostAddress) { client ->
+            val quote = client.getAttestation()
+            val base64Quote = Base64.getEncoder().encode(quote.toByteArray())
+            System.out.print(String(base64Quote))
+        }
+    }
+}

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/GetRandomCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/GetRandomCommand.kt
@@ -1,0 +1,50 @@
+package com.r3.sgx.rng.client
+
+import com.r3.sgx.core.common.SchemesSettings
+import com.r3.sgx.core.common.SgxQuote
+import com.r3.sgx.core.common.SgxReportBody
+import com.r3.sgx.enclavelethost.client.Crypto
+import picocli.CommandLine
+import java.nio.ByteBuffer
+import java.security.GeneralSecurityException
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.*
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+        name = "get-random",
+        description = ["Retrieve random numbers"],
+        mixinStandardHelpOptions = true
+)
+class GetRandomCommand : VerifyingCommand(), Callable<Unit> {
+    @CommandLine.Parameters(
+            index = "0",
+            description = ["The address of the RNG enclavelet host"]
+    )
+    var hostAddress: String = "localhost:8080"
+
+    override fun call() {
+        RngEnclaveletHostClient.withClient(hostAddress) { client ->
+            val attestation = client.getAttestation().attestation
+            val quote = verifyAttestation(attestation)
+
+            val rngResponse = client.getRandomBytes()
+            val keyHash = MessageDigest.getInstance("SHA-512").digest(rngResponse.publicKey)
+            val keyHashInReport = quote[SgxQuote.reportBody][SgxReportBody.reportData].read()
+            if (ByteBuffer.wrap(keyHash) != keyHashInReport) {
+                throw GeneralSecurityException("Key hash in attestation report doesn't match the hash of the claimed enclave key")
+            }
+
+            val signatureSchemeFactory = Crypto.getSignatureSchemeFactory(SecureRandom.getInstance("SHA1PRNG"))
+            val eddsaScheme = signatureSchemeFactory.make(SchemesSettings.EDDSA_ED25519_SHA512)
+            eddsaScheme.verify(
+                    eddsaScheme.decodePublicKey(rngResponse.publicKey),
+                    rngResponse.signature,
+                    rngResponse.randomBytes
+            )
+            val base64RandomBytes = Base64.getEncoder().encode(rngResponse.randomBytes)
+            System.out.print(String(base64RandomBytes))
+        }
+    }
+}

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/GetRandomCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/GetRandomCommand.kt
@@ -44,7 +44,7 @@ class GetRandomCommand : VerifyingCommand(), Callable<Unit> {
                     rngResponse.randomBytes
             )
             val base64RandomBytes = Base64.getEncoder().encode(rngResponse.randomBytes)
-            System.out.print(String(base64RandomBytes))
+            print(String(base64RandomBytes))
         }
     }
 }

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/PrintAttestationCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/PrintAttestationCommand.kt
@@ -36,7 +36,7 @@ class PrintAttestationCommand : Callable<Unit> {
 
         println("IAS Signature:")
         val base64Signature = Base64.getEncoder().encode(attestation.iasSignature.asReadOnlyByteBuffer())
-        System.out.println(StandardCharsets.UTF_8.decode(base64Signature))
+        println(StandardCharsets.UTF_8.decode(base64Signature))
 
         println("Quote body:")
         val quote = Cursor(SgxQuote, ByteBuffer.wrap(iasResponse.isvEnclaveQuoteBody))

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/PrintAttestationCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/PrintAttestationCommand.kt
@@ -1,0 +1,46 @@
+package com.r3.sgx.rng.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.r3.sgx.core.common.Cursor
+import com.r3.sgx.core.common.SgxQuote
+import com.r3.sgx.enclavelethost.client.ias.ReportResponse
+import com.r3.sgx.enclavelethost.grpc.GetEpidAttestationResponse
+import picocli.CommandLine
+import java.io.StringWriter
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.*
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+        name = "print-attestation",
+        description = ["Prints the attestation data in human-readable form"],
+        mixinStandardHelpOptions = true
+)
+class PrintAttestationCommand : Callable<Unit> {
+    override fun call() {
+        val base64Quote = Base64.getDecoder().wrap(System.`in`)
+        val attestation = GetEpidAttestationResponse.parseFrom(base64Quote).attestation
+
+        println("IAS Certificate:")
+        println(attestation.iasCertificate)
+
+        println("IAS Response:")
+        val objectMapper = ObjectMapper()
+        val iasResponse = objectMapper.readValue<ReportResponse>(attestation.iasResponse.toByteArray(), ReportResponse::class.java)
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT)
+        val stringWriter = StringWriter()
+        objectMapper.writeValue(stringWriter, iasResponse)
+        println(stringWriter.toString())
+
+        println("IAS Signature:")
+        val base64Signature = Base64.getEncoder().encode(attestation.iasSignature.asReadOnlyByteBuffer())
+        System.out.println(StandardCharsets.UTF_8.decode(base64Signature))
+
+        println("Quote body:")
+        val quote = Cursor(SgxQuote, ByteBuffer.wrap(iasResponse.isvEnclaveQuoteBody))
+        println(quote)
+    }
+}
+

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/RngClientCli.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/RngClientCli.kt
@@ -1,0 +1,23 @@
+package com.r3.sgx.rng.client
+
+import picocli.CommandLine
+import java.util.concurrent.Callable
+
+@CommandLine.Command(subcommands = [
+    GetAttestationCommand::class,
+    PrintAttestationCommand::class,
+    VerifyAttestationCommand::class,
+    GetRandomCommand::class
+])
+class RngClientCli : Callable<Unit> {
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            CommandLine.call(RngClientCli(), *args)
+        }
+    }
+
+    override fun call() {
+        CommandLine.usage(this, System.out)
+    }
+}

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/RngEnclaveletHostClient.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/RngEnclaveletHostClient.kt
@@ -1,0 +1,86 @@
+package com.r3.sgx.rng.client
+
+import com.google.protobuf.ByteString
+import com.r3.sgx.enclavelethost.grpc.*
+import io.grpc.ManagedChannelBuilder
+import io.grpc.stub.StreamObserver
+import java.nio.ByteBuffer
+import java.util.concurrent.LinkedBlockingQueue
+
+class RngEnclaveletHostClient(val stub: EnclaveletHostGrpc.EnclaveletHostStub) {
+    companion object {
+        fun <A> withClient(hostAddress: String, block: (RngEnclaveletHostClient) -> A): A {
+            val channel = ManagedChannelBuilder.forTarget(hostAddress).usePlaintext().build()
+            try {
+                val stub = EnclaveletHostGrpc.newStub(channel)
+                return block(RngEnclaveletHostClient(stub.withWaitForReady().withCompression("gzip")))
+            } finally {
+                channel.shutdownNow()
+            }
+        }
+    }
+
+    fun getAttestation(): GetEpidAttestationResponse {
+        val blocking = BlockingObserver<GetEpidAttestationResponse>()
+        stub.getEpidAttestation(GetEpidAttestationRequest.getDefaultInstance(), blocking)
+        return blocking.getNext()
+    }
+
+    fun getRandomBytes(): RngResponse {
+        val message = ByteBuffer.allocate(4)
+        message.putInt(1024)
+        message.rewind()
+        val blocking = BlockingObserver<ServerMessage>()
+        val observer = stub.openSession(blocking)
+        val clientMessage = ClientMessage.newBuilder()
+                .setBlob(ByteString.copyFrom(message))
+                .build()
+        observer.onNext(clientMessage)
+        val rawResponse = blocking.getNext().blob.asReadOnlyByteBuffer()
+        val bytesSize = rawResponse.getInt()
+        val bytes = ByteArray(bytesSize)
+        rawResponse.get(bytes)
+        val keySize = rawResponse.getInt()
+        val key = ByteArray(keySize)
+        rawResponse.get(key)
+        val signatureSize = rawResponse.getInt()
+        val signature = ByteArray(signatureSize)
+        rawResponse.get(signature)
+        return RngResponse(bytes, key, signature)
+    }
+}
+
+class RngResponse(
+        val randomBytes: ByteArray,
+        val publicKey: ByteArray,
+        val signature: ByteArray
+)
+
+class BlockingObserver<A> : StreamObserver<A> {
+    private sealed class Try<A> {
+        class Error<A>(val throwable: Throwable) : Try<A>()
+        class Value<A>(val value: A): Try<A>()
+    }
+
+    fun getNext(): A {
+        val element = queue.take()
+        when (element) {
+            is Try.Error -> throw element.throwable
+            is Try.Value -> return element.value
+        }
+    }
+
+    private val queue = LinkedBlockingQueue<Try<A>>()
+
+    override fun onNext(value: A) {
+        queue.add(Try.Value(value))
+    }
+
+    override fun onError(throwable: Throwable) {
+        queue.add(Try.Error(throwable))
+    }
+
+    override fun onCompleted() {
+        queue.add(Try.Error(IllegalArgumentException("Stream was closed")))
+    }
+}

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/VerifyAttestationCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/VerifyAttestationCommand.kt
@@ -1,0 +1,55 @@
+package com.r3.sgx.rng.client
+
+import com.r3.sgx.core.common.Cursor
+import com.r3.sgx.core.common.SgxQuote
+import com.r3.sgx.enclavelethost.client.AttestationVerification
+import com.r3.sgx.enclavelethost.grpc.EpidAttestation
+import com.r3.sgx.enclavelethost.grpc.GetEpidAttestationResponse
+import picocli.CommandLine
+import java.nio.ByteBuffer
+import java.util.*
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+        name = "verify-attestation",
+        description = ["Verifies the attestation data"],
+        mixinStandardHelpOptions = true
+)
+class VerifyAttestationCommand : VerifyingCommand(), Callable<Unit> {
+
+    override fun call() {
+        val base64Quote = Base64.getDecoder().wrap(System.`in`)
+        val attestation = GetEpidAttestationResponse.parseFrom(base64Quote).attestation
+        verifyAttestation(attestation)
+    }
+}
+
+open class VerifyingCommand {
+    @CommandLine.Option(
+            names = ["--accept-debug"],
+            description = ["Accept quotes from enclaves loaded in DEBUG mode"]
+    )
+    var acceptDebug: Boolean = false
+
+    @CommandLine.Option(
+            names = ["--accept-group-out-of-date"],
+            description = ["Accept attestation service responses with status GROUP_OUT_OF_DATE"]
+    )
+    var acceptGroupOutOfDate: Boolean = false
+
+    @CommandLine.Option(
+            names = ["--accept-configuration-needed"],
+            description = ["Accept attestation service responses with status CONFIGURATION_NEEDED"]
+    )
+    var acceptConfigurationNeeded: Boolean = false
+
+    fun verifyAttestation(attestation: EpidAttestation): Cursor<ByteBuffer, SgxQuote> {
+        val verification = AttestationVerification()
+        val intelPkix = verification.loadIntelPkix()
+        verification.acceptDebug = acceptDebug
+        verification.acceptGroupOutOfDate = acceptGroupOutOfDate
+        verification.acceptConfigurationNeeded = acceptConfigurationNeeded
+        return verification.verifyEpidAttestation(intelPkix, attestation)
+    }
+}
+

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/VerifyAttestationCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/VerifyAttestationCommand.kt
@@ -2,7 +2,7 @@ package com.r3.sgx.rng.client
 
 import com.r3.sgx.core.common.Cursor
 import com.r3.sgx.core.common.SgxQuote
-import com.r3.sgx.enclavelethost.client.AttestationVerification
+import com.r3.sgx.enclavelethost.client.EpidAttestationVerification
 import com.r3.sgx.enclavelethost.grpc.EpidAttestation
 import com.r3.sgx.enclavelethost.grpc.GetEpidAttestationResponse
 import picocli.CommandLine
@@ -44,12 +44,12 @@ open class VerifyingCommand {
     var acceptConfigurationNeeded: Boolean = false
 
     fun verifyAttestation(attestation: EpidAttestation): Cursor<ByteBuffer, SgxQuote> {
-        val verification = AttestationVerification()
+        val verification = EpidAttestationVerification()
         val intelPkix = verification.loadIntelPkix()
         verification.acceptDebug = acceptDebug
         verification.acceptGroupOutOfDate = acceptGroupOutOfDate
         verification.acceptConfigurationNeeded = acceptConfigurationNeeded
-        return verification.verifyEpidAttestation(intelPkix, attestation)
+        return verification.verify(intelPkix, attestation)
     }
 }
 

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/VerifyAttestationCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/VerifyAttestationCommand.kt
@@ -1,12 +1,7 @@
 package com.r3.sgx.rng.client
 
-import com.r3.sgx.core.common.Cursor
-import com.r3.sgx.core.common.SgxQuote
-import com.r3.sgx.enclavelethost.client.EpidAttestationVerification
-import com.r3.sgx.enclavelethost.grpc.EpidAttestation
 import com.r3.sgx.enclavelethost.grpc.GetEpidAttestationResponse
 import picocli.CommandLine
-import java.nio.ByteBuffer
 import java.util.*
 import java.util.concurrent.Callable
 
@@ -23,33 +18,3 @@ class VerifyAttestationCommand : VerifyingCommand(), Callable<Unit> {
         verifyAttestation(attestation)
     }
 }
-
-open class VerifyingCommand {
-    @CommandLine.Option(
-            names = ["--accept-debug"],
-            description = ["Accept quotes from enclaves loaded in DEBUG mode"]
-    )
-    var acceptDebug: Boolean = false
-
-    @CommandLine.Option(
-            names = ["--accept-group-out-of-date"],
-            description = ["Accept attestation service responses with status GROUP_OUT_OF_DATE"]
-    )
-    var acceptGroupOutOfDate: Boolean = false
-
-    @CommandLine.Option(
-            names = ["--accept-configuration-needed"],
-            description = ["Accept attestation service responses with status CONFIGURATION_NEEDED"]
-    )
-    var acceptConfigurationNeeded: Boolean = false
-
-    fun verifyAttestation(attestation: EpidAttestation): Cursor<ByteBuffer, SgxQuote> {
-        val verification = EpidAttestationVerification()
-        val intelPkix = verification.loadIntelPkix()
-        verification.acceptDebug = acceptDebug
-        verification.acceptGroupOutOfDate = acceptGroupOutOfDate
-        verification.acceptConfigurationNeeded = acceptConfigurationNeeded
-        return verification.verify(intelPkix, attestation)
-    }
-}
-

--- a/client/src/main/kotlin/com/r3/sgx/rng/client/VerifyingCommand.kt
+++ b/client/src/main/kotlin/com/r3/sgx/rng/client/VerifyingCommand.kt
@@ -1,0 +1,38 @@
+package com.r3.sgx.rng.client
+
+import com.r3.sgx.core.common.Cursor
+import com.r3.sgx.core.common.SgxQuote
+import com.r3.sgx.enclavelethost.client.EpidAttestationVerificationBuilder
+import com.r3.sgx.enclavelethost.grpc.EpidAttestation
+import picocli.CommandLine
+import java.nio.ByteBuffer
+
+open class VerifyingCommand {
+    @CommandLine.Option(
+            names = ["--accept-debug"],
+            description = ["Accept quotes from enclaves loaded in DEBUG mode"]
+    )
+    var acceptDebug: Boolean = false
+
+    @CommandLine.Option(
+            names = ["--accept-group-out-of-date"],
+            description = ["Accept attestation service responses with status GROUP_OUT_OF_DATE"]
+    )
+    var acceptGroupOutOfDate: Boolean = false
+
+    @CommandLine.Option(
+            names = ["--accept-configuration-needed"],
+            description = ["Accept attestation service responses with status CONFIGURATION_NEEDED"]
+    )
+    var acceptConfigurationNeeded: Boolean = false
+
+    fun verifyAttestation(attestation: EpidAttestation): Cursor<ByteBuffer, SgxQuote> {
+        val verification = EpidAttestationVerificationBuilder()
+                .withAcceptConfigurationNeeded(acceptConfigurationNeeded)
+                .withAcceptGroupOutOfDate(acceptGroupOutOfDate)
+                .withAcceptDebug(acceptDebug)
+                .build()
+        val intelPkix = verification.loadIntelPkix()
+        return verification.verify(intelPkix, attestation)
+    }
+}

--- a/enclave/build.gradle
+++ b/enclave/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "com.r3.sgx:api-core-host:$oblivium_version"
+    testImplementation "com.r3.sgx:enclavelet-host-client:$oblivium_version"
     testImplementation "com.r3.sgx:enclave-testing:$oblivium_version"
     testRuntimeOnly "com.r3.sgx:native-host-simulation:$oblivium_version"
 }

--- a/enclave/src/test/kotlin/com/r3/sgx/rng/enclave/RngEnclaveTest.kt
+++ b/enclave/src/test/kotlin/com/r3/sgx/rng/enclave/RngEnclaveTest.kt
@@ -1,8 +1,12 @@
 package com.r3.sgx.rng.enclave
 
 import com.r3.sgx.core.common.*
-import com.r3.sgx.core.host.*
+import com.r3.sgx.core.host.EnclaveHandle
+import com.r3.sgx.core.host.EnclaveletHostHandler
+import com.r3.sgx.core.host.EpidAttestationHostConfiguration
+import com.r3.sgx.core.host.NativeHostApi
 import com.r3.sgx.core.host.internal.Native
+import com.r3.sgx.enclavelethost.client.Crypto
 import com.r3.sgx.testing.BytesRecordingHandler
 import org.junit.After
 import org.junit.Before
@@ -134,7 +138,7 @@ class RngEnclaveTest {
         val signatureSize = responseBytes.int
         val signature = ByteArray(signatureSize)
         responseBytes.get(signature)
-        val signatureSchemeFactory = NativeHostApi.getSignatureSchemeFactory(SecureRandom.getInstance("SHA1PRNG"))
+        val signatureSchemeFactory = Crypto.getSignatureSchemeFactory(SecureRandom.getInstance("SHA1PRNG"))
         val eddsaScheme = signatureSchemeFactory.make(SchemesSettings.EDDSA_ED25519_SHA512)
         eddsaScheme.verify(
                 publicKey = eddsaScheme.decodePublicKey(publicKey),

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,5 @@ kotlin_version=1.2.71
 junit_version=4.12
 bouncycastle_version=1.60
 dropwizard_version=1.3.5
+picocli_version=3.6.0
+log4j_version=2.11.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include ':enclave'
+include ':client'
 include ':host:common'
 include ':host:frontend'
 include ':host:backend'


### PR DESCRIPTION
This PR adds a CLI client that can retrieve and verify attestation data from an enclavelet-host, and request random numbers from the rng enclavelet. Perhaps later we can split out a generic utility.

It uses the modified attestation verification class from https://github.com/corda/oblivium/pull/84